### PR TITLE
Fixes DQN.

### DIFF
--- a/rlkit/data_management/env_replay_buffer.py
+++ b/rlkit/data_management/env_replay_buffer.py
@@ -1,3 +1,4 @@
+import numpy as np
 from rlkit.data_management.simple_replay_buffer import SimpleReplayBuffer
 from gym.spaces import Box, Discrete, Tuple
 
@@ -20,6 +21,15 @@ class EnvReplayBuffer(SimpleReplayBuffer):
             observation_dim=get_dim(self._ob_space),
             action_dim=get_dim(self._action_space),
         )
+
+    def add_sample(self, observation, action, reward, terminal,
+            next_observation, **kwargs):
+
+        if isinstance(self._action_space, Discrete):
+            action = np.eye(self._action_space.n)[action]
+        super(EnvReplayBuffer, self).add_sample(
+                observation, action, reward, terminal, 
+                next_observation, **kwargs)
 
 
 def get_dim(space):

--- a/rlkit/exploration_strategies/epsilon_greedy.py
+++ b/rlkit/exploration_strategies/epsilon_greedy.py
@@ -17,10 +17,6 @@ class EpsilonGreedy(RawExplorationStrategy, Serializable):
         self.prob_random_action = prob_random_action
         self.action_space = action_space
 
-    def get_action(self, t, observation, policy, **kwargs):
-        action, agent_info = policy.get_action(observation)
-        return self.get_action_from_raw_action(action, **kwargs), agent_info
-
     def get_action_from_raw_action(self, action, **kwargs):
         if random.random() <= self.prob_random_action:
             return self.action_space.sample()


### PR DESCRIPTION
Previously, the replay buffer saved discrete actions by copying
the action n times (e.g. 3 -> [3, 3, 3, 3]) instead of encoding
it as a one-hot vector (3 -> [0, 0, 0, 1]).

Furthermore, there was a problem with the epsilon-greedy exploration
strategy, whose (irrelevant) get_action function had the wrong
interface.