### PR TITLE
Correct full name of TD3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some implemented algorithms:
     - [example script](examples/sac.py)
     - [SAC paper](https://arxiv.org/abs/1801.01290)
     - [TensorFlow implementation from author](https://github.com/rail-berkeley/softlearning)
- - Twin Dueling Deep Determinstic Policy Gradient (TD3)
+ - Twin Delayed Deep Determinstic Policy Gradient (TD3)
     - [example script](examples/td3.py)
     - [TD3 paper](https://arxiv.org/abs/1802.09477)
  - Twin Soft Actor Critic (Twin SAC)


### PR DESCRIPTION
I corrected a simple typo in README.md where TD3 was written as Twin **Dueling** Deep Deterministic Policy Gradient. I believe it should be Twin **Delayed** Deep Deterministic Policy Gradient.