### PR TITLE
removed extraneous full_observation appendage

### DIFF
--- a/rlkit/samplers/rollout_functions.py
+++ b/rlkit/samplers/rollout_functions.py
@@ -68,7 +68,6 @@ def multitask_rollout(
         if d:
             break
         o = next_o
-    full_observations.append(o)
     actions = np.array(actions)
     if len(actions.shape) == 1:
         actions = np.expand_dims(actions, 1)


### PR DESCRIPTION
I believe full_observations, observations, reward, terminals should have the same length

This extra append makes full_observation +1 over the other lists of the path