### PR TITLE
Use torch.load in run_policy

### DIFF
--- a/scripts/run_policy.py
+++ b/scripts/run_policy.py
@@ -1,7 +1,7 @@
 from rlkit.samplers.rollout_functions import rollout
 from rlkit.torch.pytorch_util import set_gpu_mode
 import argparse
-import joblib
+import torch
 import uuid
 from rlkit.core import logger
 
@@ -9,7 +9,7 @@ filename = str(uuid.uuid4())
 
 
 def simulate_policy(args):
-    data = joblib.load(args.file)
+    data = torch.load(args.file)
     policy = data['evaluation/policy']
     env = data['evaluation/env']
     print("Policy loaded")


### PR DESCRIPTION
After PR #68, `run_policy` stopped working because it was not switched
from `joblib.load` to `torch.load`.