### PR TITLE
More efficient future obs sample method in obs_dict_replay_buffer.py

### DIFF
--- a/rlkit/data_management/obs_dict_replay_buffer.py
+++ b/rlkit/data_management/obs_dict_replay_buffer.py
@@ -192,15 +192,12 @@ class ObsDictRelabelingBuffer(ReplayBuffer):
                 num_rollout_goals:last_env_goal_idx] = \
                     env_goals[goal_key]
         if num_future_goals > 0:
-            future_obs_idxs = []
-            for i in indices[-num_future_goals:]:
-                possible_future_obs_idxs = self._idx_to_future_obs_idx[i]
-                # This is generally faster than random.choice. Makes you wonder what
-                # random.choice is doing
-                num_options = len(possible_future_obs_idxs)
-                next_obs_i = int(np.random.randint(0, num_options))
-                future_obs_idxs.append(possible_future_obs_idxs[next_obs_i])
-            future_obs_idxs = np.array(future_obs_idxs)
+            ## better future obs sample algorithm
+            future_indices = indices[-num_future_goals:]
+            possible_future_obs_lens = np.array([len(self._idx_to_future_obs_idx[i]) for i in future_indices])
+            next_obs_idxs = (np.random.random(num_future_goals) * possible_future_obs_lens).astype(np.int)
+            future_obs_idxs = np.array([self._idx_to_future_obs_idx[ids][next_obs_idxs[i]] for i, ids in enumerate(future_indices)])
+
             resampled_goals[-num_future_goals:] = self._next_obs[
                 self.achieved_goal_key
             ][future_obs_idxs]


### PR DESCRIPTION
Hello, I'm reading your excellent code these days and found an interesting comment in obs_dict_replay_buffer.py.
` # This is generally faster than random.choice. Makes you wonder what random.choice is doing `.

I tried and found that using `np.random.random()` is even faster than `np.random.randint() ` when only sample one element randomly.  My solution can be about 80 times faster:
``` 
## for example
In [4]: import numpy as np 
   ...: import time 
   ...:  
   ...: N = 1000 
   ...: L = np.random.randint(1, N, size=N) 
   ...: random_lis = [np.random.random(L[i]) for i in range(N)]    # generate a list of arrays of different length                                                                                                                               

In [5]: array_len = np.array([len(random_lis[i]) for i in range(N)])                                                                                                                             
# using np.random.random()
In [6]: %timeit random_idx = (np.random.random(N) * array_len).astype(np.int)                                                                                                                    
13 µs ± 419 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
# using np.random.randint()
In [7]: %timeit random_idx = [np.random.randint(x) for x in array_len]                                                                                                                           
1e+03 µs ± 22.1 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

In addition, I use list comprehension for better performance. The change is as follows:
###  The original code

```
future_obs_idxs = []
for i in indices[-num_future_goals:]:
    possible_future_obs_idxs = self._idx_to_future_obs_idx[i]
    # This is generally faster than random.choice. Makes you wonder what
    # random.choice is doing 
    num_options = len(possible_future_obs_idxs)
    next_obs_i = int(np.random.randint(0, num_options))
    future_obs_idxs.append(possible_future_obs_idxs[next_obs_i])
future_obs_idxs = np.array(future_obs_idxs)
```

### my solution
```
future_indices = indices[-num_future_goals:]
possible_future_obs_lens = np.array([len(self._idx_to_future_obs_idx[i]) for i in future_indices])
next_obs_idxs = (np.random.random(num_future_goals) * possible_future_obs_lens).astype(np.int)
future_obs_idxs = np.array([self._idx_to_future_obs_idx[ids][next_obs_idxs[i]] for i, ids in enumerate(future_indices)]) 
```

Although the data collecting and training periods are more time-consuming, but I think `rlkit` can be more elegant and efficient.

Looking forward to your reply.