### PR TITLE
Fix for DQN and DDQN target network update

### DIFF
--- a/rlkit/torch/dqn/double_dqn.py
+++ b/rlkit/torch/dqn/double_dqn.py
@@ -55,3 +55,5 @@ class DoubleDQNTrainer(DQNTrainer):
                 'Y Predictions',
                 ptu.get_numpy(y_pred),
             ))
+            
+        self._n_train_steps_total += 1

--- a/rlkit/torch/dqn/dqn.py
+++ b/rlkit/torch/dqn/dqn.py
@@ -85,6 +85,7 @@ class DQNTrainer(TorchTrainer):
                 'Y Predictions',
                 ptu.get_numpy(y_pred),
             ))
+        self._n_train_steps_total += 1
 
     def get_diagnostics(self):
         return self.eval_statistics


### PR DESCRIPTION
Hello, 

Since the [target network update logic](https://github.com/vitchyr/rlkit/blob/ed2830923cdb6eefc838589ebac35ebc650335e8/rlkit/torch/dqn/double_dqn.py#L41
) for DQN and DDQN is tied to the `self._n_train_steps_total` variable, it becomes important to increment the  `self._n_train_steps_total` at every iteration.  



```
        """
        Soft target network updates
        """
        if self._n_train_steps_total % self.target_update_period == 0:
            ptu.soft_update_from_to(
                self.qf, self.target_qf, self.soft_target_tau
            )
```


Thanks,
Harsha Kokel.